### PR TITLE
Install requirements in setuptools setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,9 @@ import setuptools
 with open("README.md", "r") as fh:
     long_description = fh.read()
 
+with open("requirements.txt", "r") as fh:
+    requirements = fh.read().splitlines()
+
 setuptools.setup(
     name="rhasspy-client",
     version="1.0.0",
@@ -13,6 +16,7 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="https://github.com/synesthesiam/rhasspy-client",
     packages=setuptools.find_packages(),
+    install_requires=requirements,
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
Running `python3 -m rhasspyclient` after installing the pip package results in a `ModuleNotFoundError: No module named 'aiohttp'` error. This pull request adds aiohttp (as well as other future requirements in requirements.txt) to the installation requirements of setuptools.